### PR TITLE
Contribute tutorial

### DIFF
--- a/lessons/24/017/lesson.yml
+++ b/lessons/24/017/lesson.yml
@@ -1,0 +1,6 @@
+url: https://github.com/ollyfutur/mg_rna_tutorial/archive/master.zip
+instructors: Olivier Languin Cattoen
+title: Enhanced sampling for magnesium-RNA binding dynamics
+description: This tutorial will teach you how to use PLUMED, GROMACS and Python notebooks to implement an enhanced sampling strategy for magnesium-RNA binding dynamics.
+tags: CASP, RNA, Magnesium
+doi: unpublished


### PR DESCRIPTION
@gtribello I am confused because on my fork it fails with this error:

```
Python 3.8.18
/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/PlumedToHTML/PlumedToHTML.py:273: UserWarning: Problems with generated as label hidden box for label data/GAT_SAFE_README.md_working_3.datcv1 is missing
  if not soup.find("span", {"id": vallabels[3]}) : warnings.warn("Problems with generated as label hidden box for label " + vallabels[3] + " is missing")
RUNNING 4 REPLICAS. THIS IS REPLICA 0
lessons/24/015/ {'url': 'https://github.com/Iximiel/plumed-tutorial-pycv/releases/download/School/plumed-tutorial-pycv.zip', 'instructors': 'Daniele Rapetti, Toni Giorgino', 'title': 'How to use the PLUMED PyCV plugin', 'description': 'An introduction to the pycv module.  This module provides you with an action that allows you to call python from PLUMED.', 'tags': 'manual, python', 'doi': 'unpublished'}
Traceback (most recent call last):
  File "compile.py", line 315, in <module>
    process_lesson(re.sub("lesson.yml$","",str(path)),action_counts,plumed_syntax,eggdb)
  File "compile.py", line [22](https://github.com/GiovanniBussi/plumed-tutorials/actions/runs/11596420911/job/32287424091#step:8:23)2, in process_lesson
    ninputs, nfail, nfailm = processNavigation( config["title"], actions, embeds )
  File "compile.py", line 119, in processNavigation
    ni, nf = processMarkdown( "data/" + name,
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/PlumedToHTML/PlumedToHTML.py", line 470, in processMarkdown
    ninputs, nfail = processMarkdownString( inp, filename, plumedexe, plumed_names, actions, dirname, ofile, jsondir )
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/PlumedToHTML/PlumedToHTML.py", line 569, in processMarkdownString
    html = get_html(plumed_inp,
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/PlumedToHTML/PlumedToHTML.py", line [25](https://github.com/GiovanniBussi/plumed-tutorials/actions/runs/11596420911/job/32287424091#step:8:26)7, in get_html
    html += highlight( final_inpt, plumed_lexer, plumed_formatter )
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/pygments/__init__.py", line 82, in highlight
    return format(lex(code, lexer), formatter, outfile)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/pygments/__init__.py", line 64, in format
    formatter.format(tokens, realoutfile)
  File "<string>", line 187, in format
KeyError: ''
```

But I just added a new tutorial. Perhaps there is a problem in running the script in forks?

Anyway, can you merge this so that we see if there is a problem in the github actions of the main repository?