### PR TITLE
Errors now are in the bottom of the output

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -264,6 +264,8 @@ def process_lesson(path,action_counts,plumed_syntax,eggdb=None):
         # store time
         print("  time: " + str(end_time-start_time), file=eggdb)
     except Exception as e:
+      print("+++ EXCEPTION RAISED IN: ", path)
+      print("+++ EXCEPTION text:" , e)
       return (path, e)
     return None
 
@@ -323,9 +325,8 @@ if __name__ == "__main__":
                listOfErrors.append(error)
     if len(listOfErrors) > 0 :
         for path,e in listOfErrors :
-           print(path,e)
-           print("+++ EXCEPTION RAISED IN",path)
-           print("+++ EXCEPTION text:" ,e)
+           print("+++ EXCEPTION RAISED IN: ", path)
+           print("+++ EXCEPTION text:" , e)
 
         raise Exception("Errors while compiling lessons")
     # output yaml file with action counts

--- a/compile.py
+++ b/compile.py
@@ -15,9 +15,6 @@ from contextlib import contextmanager
 from PlumedToHTML import processMarkdown
 import time
 
-# global variable tracking errors
-an_error_happened=False
-
 if not (sys.version_info > (3, 0)):
    raise RuntimeError("We are using too many python 3 constructs, so this is only working with python 3")
 
@@ -267,11 +264,8 @@ def process_lesson(path,action_counts,plumed_syntax,eggdb=None):
         # store time
         print("  time: " + str(end_time-start_time), file=eggdb)
     except Exception as e:
-      print(" EXCEPTION RAISED IN",path)
-      print(e)
-      global an_error_happened
-      an_error_happened=True
-
+      return (path, e)
+    return None
 
 if __name__ == "__main__":
     nreplicas, replica, argv = 1, 0, sys.argv[1:]
@@ -309,6 +303,7 @@ if __name__ == "__main__":
         if key=="vimlink" or key=="replicalink" or key=="groups" : continue
         action_counts[key] = 0
     # loop over lesson for this replica
+    listOfErrors = []
     with open("_data/lessons" + str(replica) + ".yml","w") as eggdb:
         print("# file containing lesson database.",file=eggdb)
 
@@ -323,9 +318,16 @@ if __name__ == "__main__":
         # cycle on ordered list
         for path in sorted(pathlist, reverse=True, key=lambda m: str(m)):
             # process lesson
-            process_lesson(re.sub("lesson.yml$","",str(path)),action_counts,plumed_syntax,eggdb)
-    if an_error_happened:
-        raise Exception("one of the lessons failed")
+            error=process_lesson(re.sub("lesson.yml$","",str(path)),action_counts,plumed_syntax,eggdb)
+            if error is not None :
+               listOfErrors.append(error)
+    if len(listOfErrors) > 0 :
+        for path,e in listOfErrors :
+           print(path,e)
+           print("+++ EXCEPTION RAISED IN",path)
+           print("+++ EXCEPTION text:" ,e)
+
+        raise Exception("Errors while compiling lessons")
     # output yaml file with action counts
     action_list = [] 
     for key, value in action_counts.items() : action_list.append( {'name': key, 'number': value } )


### PR DESCRIPTION
Now if a lesson fails to be compile there is no need to backtrack through the list