### PR TITLE
adding the dependabot auto update, just for the action

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  labels:
+  - "dependabot"
+  commit-message:
+    prefix: ci


### PR DESCRIPTION
This little file will help in keeping the actions updated

I think this is useful, especially now that I received a menacing mail from GH about the deprecation of the Artifact@v3 action